### PR TITLE
A small change to the Timer Optimisation patch.

### DIFF
--- a/patches/timer_optimization_patch.cpp
+++ b/patches/timer_optimization_patch.cpp
@@ -142,7 +142,7 @@ private:
             MEMORY_BASIC_INFORMATION mbi;
             if (VirtualQuery(critSec, &mbi, sizeof(mbi)) == 0 ||
                 mbi.State != MEM_COMMIT ||
-                (mbi.Protect & (PAGE_READWRITE | PAGE_EXECUTE_READWRITE)) == 0) {
+                (mbi.Protect & (PAGE_READWRITE | PAGE_EXECUTE_READWRITE | PAGE_WRITECOPY)) == 0) {
 
                 LOG_WARNING(std::format("[TimerOpt] Skipped {} (Invalid Memory at {:#010x}; State: {:#010x}; Protect: {:#010x})",
                                         config.debugName, address, mbi.State, mbi.Protect));


### PR DESCRIPTION
The `Mono_MethodCache` and `Unk_LookAtLater` timers were being skipped on my machine (on the retail version of the game) as they have `PAGE_WRITECOPY` protection, so this PR makes the Timer Optimisation patch permit `PAGE_WRITECOPY` protection, and adds slightly more detail to the warning message.