### PR TITLE
Display a countdown for the rebounce delay of a patch pending reinstallation

### DIFF
--- a/gui.cpp
+++ b/gui.cpp
@@ -386,6 +386,23 @@ namespace SettingsGui {
                                             ImGui::TextDisabled("[EXPERIMENTAL]");
                                         }
 
+                                        if (enabled & patch->PendingReinstall()) {
+                                            auto then = patch->GetLastSettingChange();
+                                            auto when = then + OptimizationPatch::SETTING_CHANGE_DEBOUNCE;
+                                            auto now = std::chrono::steady_clock::now();
+                                            auto how = when - now;
+
+                                            if (when > now) {
+                                                auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(how).count();
+                                                ImGui::SameLine();
+                                                ImGui::TextColored(ImVec4(0.89f, 0.11f, 0.89f, 1.0f),
+                                                                   "| Reinstalling in %.2f second%c", ms / 1000.0f, ms == 1000 ? ' ' : 's');
+                                            } else {
+                                                ImGui::SameLine();
+                                                ImGui::TextColored(ImVec4(0.89f, 0.11f, 0.89f, 1.0f), "| Reinstalling...");
+                                            }
+                                        }
+
                                         if (hasError || !compatible || experimental) {
                                             ImGui::PopStyleColor();
                                         }

--- a/optimization.h
+++ b/optimization.h
@@ -21,12 +21,12 @@ public:
         std::chrono::steady_clock::time_point start;
     };
 
+    static constexpr auto SETTING_CHANGE_DEBOUNCE = std::chrono::seconds(2);
 protected:
     std::mutex statsMutex;
     std::mutex patchMutex;
     SampleWindow currentWindow;
     static constexpr auto SAMPLE_INTERVAL = std::chrono::seconds(5);
-    static constexpr auto SETTING_CHANGE_DEBOUNCE = std::chrono::seconds(2);
 
     void* originalFunc;
     std::string patchName;
@@ -143,6 +143,8 @@ public:
     bool IsEnabled() const { return isEnabled.load(); }
     double GetLastSampleRate() const { return lastSampleRate; }
     const std::string& GetLastError() const { return lastError; }
+    bool PendingReinstall() const { return pendingReinstall; }
+    std::chrono::steady_clock::time_point GetLastSettingChange() const { return lastSettingChange; }
 
     // Metadata management
     void SetMetadata(const PatchMetadata& meta);


### PR DESCRIPTION
Just to make it a bit more obvious that there's a delay to setting changes taking effect, and when that delay has elapsed.

Vid: https://github.com/user-attachments/assets/16d197b9-2634-478f-bb44-b40aae659182