### PR TITLE
Rewrite the Smooth Patch (Precise Flavour) patch for maybe better frame-pacing. (And also add a frame-rate limiter).

### DIFF
--- a/patches/smooth_patch_precise.cpp
+++ b/patches/smooth_patch_precise.cpp
@@ -1,100 +1,149 @@
 #include "../patch_system.h"
 #include "../patch_helpers.h"
 #include "../logger.h"
+#include <bit>
 
 #pragma comment(lib, "ntdll.lib")
 
 extern "C" __declspec(dllimport) NTSTATUS __stdcall NtDelayExecution(BOOLEAN Alertable, LARGE_INTEGER* Interval);
+extern "C" __declspec(dllimport) NTSTATUS __stdcall NtQueryTimerResolution(ULONG* MaximumTime, ULONG* MinimumTime, ULONG* CurrentTime);
+
+static float tickRateLimitSettingStorage;
+static float tickRateLimit;
+
+static float frameRateLimitSettingStorage;
+static float frameRateLimit;
+static float frameRateLimitInactiveSettingStorage;
+static float frameRateLimitInactive;
+
+static double qpcToHectonanosecondsMultiplier;
+static double hectonanosecondsToQPCMultiplier;
+static uint64_t performanceFrequency;
+
+static ULONG timerResolution = 0;
+static uint64_t timerFrequency = 1;
+
+static uint64_t idealSimulationCycleTime;
+static uint64_t previousSimulationCycleTime = 0;
+
+static uint64_t idealPresentationFrameTime;
+static uint64_t idealPresentationFrameInactiveTime;
+static uint64_t previousPresentationFrameTime = 0;
+
+struct ScriptHostBase {
+    uint64_t HookedIdleSimulationCycle();
+};
+
+static decltype(&ScriptHostBase::HookedIdleSimulationCycle) originalIdleSimulationCycle;
+
+uint64_t WaitUntilPrecisely(uint64_t time, uint64_t now) {
+    // We'll sleep for as long as we can (within the bounds of the timer-frequency).
+    uint64_t sleepUntil = (time / timerFrequency) * timerFrequency;
+
+    if (sleepUntil > now) {
+        // We use a relative sleep here instead of an absolute sleep
+        // to avoid potential issues with floating-point precision
+        // should the absolute time-stamp exceed a width of 53-bits.
+        uint64_t durationInQPC = sleepUntil - now;
+        uint64_t duration = static_cast<uint64_t>(durationInQPC * qpcToHectonanosecondsMultiplier);
+        // NtDelayExecution uses a negative duration to denote a relative sleep instead of an absolute sleep.
+#pragma warning(suppress : 4146, justification : "Two's complement is not an error. Good grief.")
+        duration = -duration;
+        NtDelayExecution(false, reinterpret_cast<LARGE_INTEGER*>(&duration));
+    }
+
+    // When we can sleep no longer, we'll busy wait.
+    do { QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER*>(&now)); } while (now < time);
+
+    return now;
+}
+
+uint64_t ScriptHostBase::HookedIdleSimulationCycle() {
+    // Note that idealSimulationCycleTime may change during the sleep performed later on,
+    // so it's very important that we read this now so as to avoid a potential division-by-zero.
+    uint64_t idealTime = idealSimulationCycleTime;
+
+    // I don't know what the boolean at 0xa60 is, but the game's code skips sleeping if it's zero,
+    // so if it's zero we'll avoid sleeping.
+    if ((idealTime == 0) | !*reinterpret_cast<const uint8_t*>((reinterpret_cast<uintptr_t>(this) + 0xa60))) { return previousSimulationCycleTime; }
+
+    uint64_t idealTimeForThisCycle = previousSimulationCycleTime + idealTime;
+
+    uint64_t now;
+    QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER*>(&now));
+
+    // If we're on time, we'll wait for the ideal cycle-time to elapse.
+    if (now < idealTimeForThisCycle) { now = WaitUntilPrecisely(idealTimeForThisCycle, now); }
+
+    // We'll round down the time so that if we're running late the next cycle will occur earlier.
+    previousSimulationCycleTime = (now / idealTime) * idealTime;
+
+    return previousSimulationCycleTime;
+}
+
+void __stdcall DelayAfterFramePresentation(uintptr_t graphicsDeviceStructure) {
+    // This might actually denote if the graphics device is lost instead, I'm not sure.
+    bool gameWindowIsNotForeground = *reinterpret_cast<const uint8_t*>(graphicsDeviceStructure + 0x8d);
+
+    uint64_t idealTime = gameWindowIsNotForeground ? idealPresentationFrameInactiveTime : idealPresentationFrameTime;
+
+    if (idealTime == 0) { return; }
+
+    uint64_t idealTimeForThisFrame = previousPresentationFrameTime + idealTime;
+
+    uint64_t now;
+    QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER*>(&now));
+
+    // If we're on time, we'll wait for the ideal frame-time to elapse.
+    while (now < idealTimeForThisFrame) { now = WaitUntilPrecisely(idealTimeForThisFrame, now); }
+
+    // We'll round down the time so that if we're running late the next frame will occur earlier.
+    previousPresentationFrameTime = (now / idealTime) * idealTime;
+}
 
 class SmoothPatchPrecise : public OptimizationPatch {
   private:
-    // This is Sims3::Scripting::ScriptHostBase::IdleSimulationCycle called from Sims3::MonoEngine::MonoScriptHost::Simulate, I think
-    static inline const AddressInfo simulationFrameRateLimiterFunctionAddressInfo = {.name = "SmoothPatchPrecise::simulationFrameTimingSetup",
+    // This is a call of Sims3::Scripting::ScriptHostBase::IdleSimulationCycle from Sims3::MonoEngine::MonoScriptHost::Simulate.
+    static inline const AddressInfo idleSimulationCycleCallAddressInfo = {.name = "SmoothPatchPrecise::idleSimulationCycleCall",
         .addresses =
             {
-                {GameVersion::Retail, 0x00769600},
-                {GameVersion::Steam, 0x007694b0},
-                {GameVersion::EA, 0x0076a430},
+                {GameVersion::Retail, 0x00d8246e},
+                {GameVersion::Steam, 0x00d81fde},
+                {GameVersion::EA, 0x00d8239e},
             },
-        .pattern = "C7 86 58 0A 00 00 40 8A F7 01 89 8E 5C 0A 00 00 8B 86 58 0A 00 00 8B B6 5C 0A 00 00 3B F1 7C 28 7F 04 3B C1 76 22 51 68 40 42 0F 00 56 50",
-        .patternOffset = -218};
+        .pattern = "8B 86 C0 0A 00 00 3B C3 74 0F 8B 4C 24 5C 8B 11 6A 01 53 50 8B 42 24 FF D0 8B CE",
+        .patternOffset = 27};
 
-    // This is the global (gSimulationThreadId) set by Sims3::Utility::SetSimulationThreadId (called from Sims3::Scripting::ScriptService::Init)
-    static inline const AddressInfo simulatorThreadIDAddressInfo = {
-        .name = "SmoothPatchPrecise::simulatorThreadID",
+    // This is a comparison that precedes a branch, which the games uses to limit
+    // the frame-rate to roughly 30 FPS if the game's window is not the foreground window
+    // (or maybe only if the graphics device is lost, I'm not sure).
+    // We hijack this location to perform unconditional frame-rate limiting.
+    static inline const AddressInfo limitFrameRateWhenInactiveAddressInfo = {
+        .name = "SmoothPatchPrecise::limitFrameRateWhenInactive",
         .addresses =
             {
-                {GameVersion::Retail, 0x011d9a8c},
-                {GameVersion::Steam, 0x011d8a8c},
-                {GameVersion::EA, 0x01232b3c},
+                {GameVersion::Retail, 0x00eca64a},
+                {GameVersion::Steam, 0x00ec9fba},
+                {GameVersion::EA, 0x00ec9f9a},
             },
-        // Pattern: 8B 06 8B 50 10 83 C4 04 8B CE FF D2 84 C0 74 DC 6A 00 6A 00 6A 00 6A 00
-        // Immediately preceding this code is a call to a function,
-        // the address written to in the body of that function is the address of the simulator's thread-ID.
+        .pattern = "80 BE 8D 00 00 00 00 5E 74 15 8D 4C 24 24 51 C7 44 24 28 1E 00 00 00",
     };
 
-    static inline const AddressInfo _alldivAddressInfo = {
-        .name = "SmoothPatchPrecise::_alldiv",
-        .addresses =
-            {
-                {GameVersion::Retail, 0x00f7f8e0},
-                {GameVersion::Steam, 0x00f7ef00},
-                {GameVersion::EA, 0x00fc47d0},
-            },
-        // Immediately after the pattern of `simulationFrameTimingSetup` is a call to _alldiv.
-        // (Ghidra will have recognised it anyway: you can simply search the symbols for "_alldiv").
-    };
+    static constexpr uint32_t oneSecondAsHectonanoseconds = 10'000'000;
 
     std::vector<PatchHelper::PatchLocation> patchedLocations;
-    float frameRateLimitSettingStorage;
-    float frameRateLimit;
-    float frameTimeAsNanoseconds;
-
-    static constexpr uintptr_t offsetOfFrameTime = 30;
-    static constexpr uintptr_t offsetOfNegativeDelayLo0 = 176;
-    static constexpr uintptr_t offsetOfNegativeDelayLo1 = 188;
-    static constexpr uintptr_t offsetOfDelayLo0 = 212;
-    static constexpr uintptr_t offsetOfDelayLo1 = 224;
-    static constexpr uintptr_t offsetOfSleepCall = 256;
-
-    static constexpr uint32_t oneSecondAsNanoseconds = 1'000'000'000;
-
-    bool CanPatchSafely() {
-        // As we're patching a (transitive) call to a sleep function,
-        // it is very likely that we'll patch the function whilst the
-        // simulator thread is sleeping: in such a scenario the thread will
-        // wake up and return into the middle of an instruction, and then crash the game.
-        // To avoid this happening,
-        // we'll patch the function only if the simulator thread is not running.
-
-        auto simulatorThreadIDAddress = simulatorThreadIDAddressInfo.Resolve();
-
-        if (!simulatorThreadIDAddress) { return Fail("Could not resolve simulatorThreadID address"); }
-
-        uint32_t simulatorThreadID = *reinterpret_cast<const uint32_t*>(*simulatorThreadIDAddress);
-
-        if (simulatorThreadID == 0) { return true; }
-
-        HANDLE simulatorThread = OpenThread(THREAD_QUERY_INFORMATION, false, simulatorThreadID);
-
-        if (simulatorThread == nullptr) { return true; }
-
-        CloseHandle(simulatorThread);
-
-        return Fail("The game must be restarted for this patch to be installed/uninstalled.");
-    }
+    uint32_t updateCounter = 0;
 
   public:
     SmoothPatchPrecise() : OptimizationPatch("SmoothPatchPrecise", nullptr) {
-        // The game's code/debug-printing refers to this as the simulation frame-rate,
-        // but users are used to it being called the tick-rate, so we'll call it that in the UI.
-        RegisterFloatSetting(&frameRateLimitSettingStorage, "tickRateLimit", SettingUIType::InputBox,
-            60.0f,         // Most people will be using a 60 Hz display, so 60 is a reasonable default.
-            0.25f,         // (oneSecondAsNanoseconds / 0.25) is close to overflowing a 32-bit value.
-            1000000001.0f, // (oneSecondAsNanoseconds / (oneSecondAsNanoseconds + 1)) will truncate to 0.
-            "Tick-rate limit",
+        RegisterFloatSetting(&tickRateLimitSettingStorage, "tickRateLimit", SettingUIType::InputBox,
+            480.0f, // Most people will be using a 60 Hz display, so we default to a multiple of 60,
+                    // 480 TPS should be fine for weaker processors.
+            0.0f,
+            10000.0f, // 10,000 Hz? Whatever, sure.
+            "Tick-rate limit (how many times a second the game will simulate a slice of time)",
             {
-                {"Unlimited", 1000000001.0f},
+                {"Unlimited##TPS", 0.0f},
                 {"30 TPS", 30.0f},
                 {"60 TPS", 60.0f},
                 {"75 TPS", 75.0f},
@@ -106,132 +155,124 @@ class SmoothPatchPrecise : public OptimizationPatch {
                 {"240 TPS", 240.0f},
                 {"360 TPS", 360.0f},
                 {"480 TPS", 480.0f},
-                {"500 TPS", 500.0f},
-                {"1,000 TPS", 1000.0f},
+                {"960 TPS", 960.0f},
+            });
+
+        RegisterFloatSetting(&frameRateLimitSettingStorage, "frameRateLimit", SettingUIType::InputBox,
+            60.0f, // Most people will be using a 60 Hz display.
+            0.0f,
+            10000.0f, // 10,000 Hz? Whatever, sure.
+            "Frame-rate limit (how many frames a second the game will present to the display)",
+            {
+                {"Unlimited##FPS", 0.0f},
+                {"30 FPS##A", 30.0f},
+                {"60 FPS##A", 60.0f},
+                {"75 FPS##A", 75.0f},
+                {"120 FPS##A", 120.0f},
+                {"144 FPS##A", 144.0f},
+                {"160 FPS##A", 160.0f},
+                {"165 FPS##A", 165.0f},
+                {"200 FPS##A", 200.0f},
+                {"240 FPS##A", 240.0f},
+                {"360 FPS##A", 360.0f},
+                {"480 FPS##A", 480.0f},
+                {"960 FPS##A", 960.0f},
+            });
+
+        RegisterFloatSetting(&frameRateLimitInactiveSettingStorage, "frameRateLimitInactive", SettingUIType::InputBox,
+            30.0f, // This is what the game defaults to (roughly).
+            -1.0f,
+            10000.0f, // 10,000 Hz? Whatever, sure.
+            "Inactive frame-rate limit (for when the game's window isn't active)",
+            {
+                {"Match FPS", -1.0f},
+                {"30 FPS##I", 30.0f},
+                {"60 FPS##I", 60.0f},
+                {"75 FPS##I", 75.0f},
+                {"120 FPS##I", 120.0f},
+                {"144 FPS##I", 144.0f},
+                {"160 FPS##I", 160.0f},
+                {"165 FPS##I", 165.0f},
+                {"200 FPS##I", 200.0f},
+                {"240 FPS##I", 240.0f},
+                {"360 FPS##I", 360.0f},
+                {"480 FPS##I", 480.0f},
+                {"960 FPS##I", 960.0f},
             });
     }
 
     bool Install() override {
         if (isEnabled) return true;
-        isEnabled = true;
-
-        frameRateLimit = frameRateLimitSettingStorage;
-        frameTimeAsNanoseconds = static_cast<float>(oneSecondAsNanoseconds) / frameRateLimit;
-
-        uint32_t frameDelay = static_cast<uint32_t>(frameTimeAsNanoseconds);
-#pragma warning(disable : 4146, justification : "Two's complement is not an error. Good grief.")
-        uint32_t frameDelayNegated = -frameDelay;
-
-        auto simulationFrameRateLimiterFunctionAddress = simulationFrameRateLimiterFunctionAddressInfo.Resolve();
-
-        if (!simulationFrameRateLimiterFunctionAddress) { return Fail("Could not resolve simulationFrameRateLimiterFunction address"); }
-
-        uintptr_t base = *simulationFrameRateLimiterFunctionAddress;
-
-        if (patchedLocations.size() != 0) {
-            // If we've already patched this function,
-            // then we're reinstalling the patch because the user changed a setting.
-            // We can do this safely as we're just changing immediate values.
-
-            lastError.clear();
-            LOG_INFO("[SmoothPatchPrecise] Reinstalling...");
-            LOG_INFO(std::format("[SmoothPatchPrecise] frameRateLimit: {}; frameTimeAsNanoseconds: {:.2f}", frameRateLimit, frameTimeAsNanoseconds));
-
-            bool successful = true;
-            auto tx = PatchHelper::BeginTransaction();
-
-            successful &= PatchHelper::WriteDWORD(base + offsetOfFrameTime, (uintptr_t)&frameTimeAsNanoseconds, &tx.locations);
-            successful &= PatchHelper::WriteDWORD(base + offsetOfNegativeDelayLo0, frameDelayNegated, &tx.locations);
-            successful &= PatchHelper::WriteDWORD(base + offsetOfNegativeDelayLo1, frameDelayNegated, &tx.locations);
-            successful &= PatchHelper::WriteDWORD(base + offsetOfDelayLo0, frameDelay, &tx.locations);
-            successful &= PatchHelper::WriteDWORD(base + offsetOfDelayLo1, frameDelay, &tx.locations);
-
-            if (!successful || !PatchHelper::CommitTransaction(tx)) {
-                PatchHelper::RollbackTransaction(tx);
-                return Fail("Failed to reinstall");
-            }
-
-            LOG_INFO("[SmoothPatchPrecise] Successfully reinstalled");
-            return true;
-        }
-
-        if (!CanPatchSafely()) return false;
-
         lastError.clear();
         LOG_INFO("[SmoothPatchPrecise] Installing...");
-        LOG_INFO(std::format("[SmoothPatchPrecise] frameRateLimit: {}; frameTimeAsNanoseconds: {:.2f}", frameRateLimit, frameTimeAsNanoseconds));
 
-        auto _alldivAddress = _alldivAddressInfo.Resolve();
+        tickRateLimit = tickRateLimitSettingStorage;
+        frameRateLimit = frameRateLimitSettingStorage;
+        frameRateLimitInactive = frameRateLimitInactiveSettingStorage < 0.0f ? frameRateLimit : frameRateLimitInactiveSettingStorage;
 
-        if (!_alldivAddress) { return Fail("Could not resolve _alldiv address"); }
+        QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER*>(&performanceFrequency));
 
-        uintptr_t _alldiv = *_alldivAddress;
+        double frequency = static_cast<double>(performanceFrequency);
+        idealSimulationCycleTime = tickRateLimit == 0 ? 0 : static_cast<uint64_t>(frequency / tickRateLimit);
+        idealPresentationFrameTime = frameRateLimit == 0 ? 0 : static_cast<uint64_t>(frequency / frameRateLimit);
+        idealPresentationFrameInactiveTime = frameRateLimitInactive == 0 ? 0 : static_cast<uint64_t>(frequency / frameRateLimitInactive);
+        qpcToHectonanosecondsMultiplier = static_cast<double>(oneSecondAsHectonanoseconds) / frequency;
+        hectonanosecondsToQPCMultiplier = frequency / oneSecondAsHectonanoseconds;
+
+        UpdateTimerFrequency();
+
+        LOG_INFO(std::format("[SmoothPatchPrecise] tickRateLimit: {}; frameRateLimit: {}; frameRateLimitInactive: {}; performanceFrequency: {}; idealSimulationCycleTime: {}; idealPresentationFrameTime: {}; "
+                             "idealPresentationFrameInactiveTime: {}; timerResolution: {}, timerFrequency: {}; qpcToHectonanosecondsMultiplier: {}; hectonanosecondsToQPCMultiplier: {}",
+            tickRateLimit, frameRateLimit, frameRateLimitInactive, performanceFrequency, idealSimulationCycleTime, idealPresentationFrameTime, idealPresentationFrameInactiveTime, timerResolution, timerFrequency,
+            qpcToHectonanosecondsMultiplier, hectonanosecondsToQPCMultiplier));
+
+        auto idleSimulationCycleCallAddress = idleSimulationCycleCallAddressInfo.Resolve();
+        if (!idleSimulationCycleCallAddress) { return Fail("Could not resolve idleSimulationCycleCall address"); }
+        uintptr_t idleSimulationCycleCall = *idleSimulationCycleCallAddress;
+
+        auto limitFrameRateWhenInactiveAddress = limitFrameRateWhenInactiveAddressInfo.Resolve();
+        if (!limitFrameRateWhenInactiveAddress) { return Fail("Could not resolve limitFrameRateWhenInactive address"); }
+        uintptr_t limitFrameRate = *limitFrameRateWhenInactiveAddress;
 
         bool successful = true;
         auto tx = PatchHelper::BeginTransaction();
 
-        successful &= PatchHelper::WriteDWORD(base + offsetOfFrameTime, (uintptr_t)&frameTimeAsNanoseconds, &tx.locations);
-        successful &= PatchHelper::WriteDWORD(base + offsetOfNegativeDelayLo0, frameDelayNegated, &tx.locations);
-        successful &= PatchHelper::WriteDWORD(base + offsetOfNegativeDelayLo1, frameDelayNegated, &tx.locations);
-        successful &= PatchHelper::WriteDWORD(base + offsetOfDelayLo0, frameDelay, &tx.locations);
-        successful &= PatchHelper::WriteDWORD(base + offsetOfDelayLo1, frameDelay, &tx.locations);
-
         // clang-format off
-        uint8_t preciseSleepCall[34] = {
-            /* We could use the more compact `0x6A imm8` encoding of push here,
-               but we don't so that we can pad this block with one nop instead of two. */
-            0x68, 0xFF, 0xFF, 0xFF, 0xFF, // push 0xFFFFFFFF
-            0x68, 0x9C, 0xFF, 0xFF, 0xFF, // push -100
-            0x56,                         // push esi
-            0x50,                         // push eax
-            /* We divide by -100 to convert the nanosecond-based value in eax:esi
-               to a hectonanosecond-based value. */
-            /* We divide by -100 instead of 100 so that the result is negative,
-               which we want because NtDelayExecution uses a negative interval
-               for sleeping by a relative duration. */
-        //12:
-            0xE8, 0x77, 0x77, 0x77, 0x77, // call _alldiv
-            /* The duration to sleep for is currently held across eax:edx,
-               so we store those on the stack for the `Interval` argument of NtDelayExecution. */
-            0x52,                         // push edx
-            0x50,                         // push eax
-            0x54,                         // push esp
-            /* A non-alertable sleep, in hopes of consistent frame-pacing. */
-            0x6A, 0x00,                   // push 0
-        //22:
-            0xE8, 0x77, 0x77, 0x77, 0x77, // call NtDelayExecution
-            0x83, 0304, 0x08,             // add esp, 8
-            0x0F, 0x1F, 0x40, 0x00,       // nop
+        uint8_t frameRateLimiter[9] = {
+            /* A DS prefix to pad this instruction such that the following call
+               ends at the same place as the original CMP instruction,
+               making this patch safe to uninstall at any time. */
+            0x3E, 0x56,                   // ds: push esi
+        //2:
+            0xE8, 0x77, 0x77, 0x77, 0x77, // call DelayAfterFramePresentation
+            0x5E,                         // pop esi
+            0xEB,                         // jmp <rel8>
         };
         // clang-format on
 
-        uintptr_t sleepCallBase = base + offsetOfSleepCall;
-        uintptr_t ntDelayExecution = reinterpret_cast<uintptr_t>(&NtDelayExecution);
+        uintptr_t delayCallDisplacement = PatchHelper::CalculateRelativeOffset(limitFrameRate + 2, reinterpret_cast<uintptr_t>(&DelayAfterFramePresentation));
+        std::memcpy(frameRateLimiter + 2 + 1, &delayCallDisplacement, 4);
 
-        int32_t _alldivDisplacement = PatchHelper::CalculateRelativeOffset(sleepCallBase + 12, _alldiv);
-        int32_t delayDisplacement = PatchHelper::CalculateRelativeOffset(sleepCallBase + 22, ntDelayExecution);
+        uintptr_t idleSimulationCycle = std::bit_cast<uintptr_t>(&ScriptHostBase::HookedIdleSimulationCycle);
+        int32_t idleCallDisplacement = PatchHelper::CalculateRelativeOffset(idleSimulationCycleCall, idleSimulationCycle);
 
-        std::memcpy(preciseSleepCall + 13, &_alldivDisplacement, 4);
-        std::memcpy(preciseSleepCall + 23, &delayDisplacement, 4);
-
-        successful &= PatchHelper::WriteProtectedMemory(reinterpret_cast<uint8_t*>(sleepCallBase), preciseSleepCall, 34, &tx.locations);
+        successful &= PatchHelper::WriteDWORD(idleSimulationCycleCall + 1, idleCallDisplacement, &tx.locations);
+        successful &= PatchHelper::WriteProtectedMemory(reinterpret_cast<void*>(limitFrameRate), frameRateLimiter, 9, &tx.locations);
 
         if (!successful || !PatchHelper::CommitTransaction(tx)) {
             PatchHelper::RollbackTransaction(tx);
-            isEnabled = false;
             return Fail("Failed to install");
         }
 
         patchedLocations = tx.locations;
 
+        isEnabled = true;
         LOG_INFO("[SmoothPatchPrecise] Successfully installed");
         return true;
     }
 
     bool Uninstall() override {
         if (!isEnabled) return true;
-        isEnabled = false;
-        if (!CanPatchSafely()) return false;
 
         lastError.clear();
         LOG_INFO("[SmoothPatchPrecise] Uninstalling...");
@@ -241,13 +282,47 @@ class SmoothPatchPrecise : public OptimizationPatch {
             return Fail("Failed to restore original code");
         }
 
+        isEnabled = false;
         LOG_INFO("[SmoothPatchPrecise] Successfully uninstalled");
         return true;
+    }
+
+    bool UpdateTimerFrequency() {
+        ULONG maxTimerResolution;
+        ULONG minTimerResolution;
+        ULONG currentTimerResolution;
+        NtQueryTimerResolution(&maxTimerResolution, &minTimerResolution, &currentTimerResolution);
+        if (currentTimerResolution != timerResolution) {
+            timerResolution = currentTimerResolution;
+            timerFrequency = static_cast<uint64_t>(static_cast<double>(timerResolution) * hectonanosecondsToQPCMultiplier);
+            // We want to avoid the remote possibility of division-by-zero.
+            timerFrequency = timerFrequency == 0 ? 1 : timerFrequency;
+            return true;
+        }
+        return false;
+    }
+
+    void Update() override {
+        // The timer-frequency may change if the Timer Optimization Patch is installed/uninstalled.
+        // Alternatively, software like Special K may change it.
+        // We don't want to be issuing syscalls too often so we'll
+        // update the timer-frequency only every so often.
+        if ((updateCounter & 255) == 0) {
+            uint64_t oldTimerFrequency = timerFrequency;
+            if (UpdateTimerFrequency()) { LOG_INFO(std::format("[SmoothPatchPrecise] Updated timerFrequency from {} to {}", oldTimerFrequency, timerFrequency)); }
+        }
+
+        ++updateCounter;
+
+        OptimizationPatch::Update();
     }
 };
 
 REGISTER_PATCH(SmoothPatchPrecise, {.displayName = "Smooth Patch (Precise Flavour)",
-                                       .description = "Adjusts the game's simulation tick-rate limiter directly. For smoother gameplay.\nMuch like LazyDuchess's original Smooth Patch.",
+                                       .description = "Adjusts the game's simulation tick-rate limiter directly. For smoother gameplay.\n"
+                                                      "Much like LazyDuchess's original Smooth Patch.\n\n"
+                                                      "A frame-rate limiter is also included, for convenience.\n"
+                                                      "Setting the tick-rate limit to a multiple of the frame-rate limit may, theoretically, result in better frame-pacing.",
                                        .category = "Performance",
                                        .experimental = false,
                                        .supportedVersions = VERSION_ALL,
@@ -256,4 +331,5 @@ REGISTER_PATCH(SmoothPatchPrecise, {.displayName = "Smooth Patch (Precise Flavou
                                            "This patch was authored by \"Just Harry\".",
                                            "Unlike the original Smooth Patch, this patch does not alter sleep-durations unrelated to the game's simulator.",
                                            "Additionally, this patch can sleep for sub-millisecond durations, so there is a difference, for example, between 750 TPS and 1,000 TPS.",
+                                           "The game's original tick-rate limiter is bypassed entirely, in favour of a bespoke implementation that uses both a sleep function and a busy wait for enhanced precision.",
                                        }})


### PR DESCRIPTION
This is a complete rewrite of the patch, so the diff is a bit hopeless.

In short, instead of simply rejigging the constants used by the game's original tick-rate limiter, the tick-rate limiter is replaced entirely with a bespoke implementation which uses a hybrid sleep-then-busy-wait. (It's called from only one place, so that call-site is patched instead of the function itself). \
This might result in better frame-pacing ¯\\\_(ツ)_/¯. I don't know: I really did this only because I don't understand how the game's original tick-rate limiter works, and I was hoping to eliminate a stutter by replacing it. (The stutter was unrelated).

As a bonus, a frame-rate limiter has been added also: hijacking a bit of code that the game usually uses to limit the game to roughly 30 FPS (it just sleeps for 30 milliseconds) when the game's window is not the foreground window (or only if the graphics device is lost? I'm not sure).

Additionally, we can get rid of all the `CanPatchSafely` guff, as this version of the patch can be safely installed/uninstalled at will.

The preset TPS/FPS values of 500 and 1,000 have been altered to 480 and 960 so that they're multiples of 60, which may, theoretically, result in better frame-pacing as the tick-rate and the frame-rate will share a common time-step. Again ¯\\\_(ツ)_/¯

The default tick-rate limit has been bumped up to 480, as having brushed up on some of the game's simulation code recently I'm convinced that there is a gameplay benefit to raising it above the frame-rate.
